### PR TITLE
Move all styles to "active_admin_pro.scss"

### DIFF
--- a/app/assets/stylesheets/active_admin_pro.scss
+++ b/app/assets/stylesheets/active_admin_pro.scss
@@ -18,3 +18,6 @@
 
 // Layout Styles
 @import "active_admin_pro/layout/**/*";
+
+// Font Awesome
+@import url("https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css");

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -8,22 +8,6 @@ ActiveAdmin.application.tap do |config|
   # Prefer short date and time format
   config.localize_format = :short
 
-  # Include Font Awesome in ActiveAdmin
-  config.register_stylesheet "//maxcdn.bootstrapcdn.com/font-awesome/#{ENV['FONT_AWESOME_VERSION'] || '4.5.0'}/css/font-awesome.min.css"
-
-  # Add Apple web application icons
-  base_url = "//s3.amazonaws.com/codelation.activeadmin/apple-touch-icon"
-  sizes = [76, 120, 152, 167, 180]
-  config.register_stylesheet "#{base_url}.png", media: nil, rel: "apple-touch-icon"
-  sizes.each do |size|
-    config.register_stylesheet(
-      "#{base_url}-#{size}x#{size}.png",
-      media: nil,
-      rel:   "apple-touch-icon",
-      sizes: "#{size}x#{size}"
-    )
-  end
-
   # Add the meta tags to enable Active Admin as an iOS home screen app
   config.meta_tags ||= {}
   config.meta_tags["apple-mobile-web-app-capable"] ||= "yes"


### PR DESCRIPTION
Active Admin 1.1.0 deprecated this asset registration: https://github.com/activeadmin/activeadmin/pull/5060